### PR TITLE
Shortened pat_to_img and ignored .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vscode settings
+.vscode/

--- a/GameOfLife/patterns.py
+++ b/GameOfLife/patterns.py
@@ -119,7 +119,6 @@ class Pattern():
         new_img = Image.new('RGB', img_size, (255, 255, 255))
         
         for cell in self.cells:
-            index = (cell[1], cell[0])
-            new_img.putpixel(index, (0, 0, 0))
+            new_img.putpixel(cell, (0, 0, 0))
         
         new_img.save(filename, 'PNG')

--- a/GameOfLife/patterns.py
+++ b/GameOfLife/patterns.py
@@ -122,4 +122,3 @@ class Pattern():
             new_img[cell[1]][cell[0]] = (0, 0, 0)
         
         new_img.save(filename, 'PNG')
-        

--- a/GameOfLife/patterns.py
+++ b/GameOfLife/patterns.py
@@ -119,6 +119,7 @@ class Pattern():
         new_img = Image.new('RGB', img_size, (255, 255, 255))
         
         for cell in self.cells:
-            new_img.putpixel(cell, (0, 0, 0))
+            index = (cell[1], cell[0])
+            new_img.putpixel(index, (0, 0, 0))
         
         new_img.save(filename, 'PNG')

--- a/GameOfLife/patterns.py
+++ b/GameOfLife/patterns.py
@@ -119,6 +119,6 @@ class Pattern():
         new_img = Image.new('RGB', img_size, (255, 255, 255))
         
         for cell in self.cells:
-            new_img[cell[1]][cell[0]] = (0, 0, 0)
+            new_img.putpixel(cell, (0, 0, 0))
         
         new_img.save(filename, 'PNG')

--- a/GameOfLife/patterns.py
+++ b/GameOfLife/patterns.py
@@ -105,7 +105,7 @@ class Pattern():
                     cell_arr.append(cur_cell)
 
         self.cells = cell_arr
-
+    
     def pat_to_img(self, filename):
         '''
         Saves a .png version of the pattern.
@@ -113,22 +113,13 @@ class Pattern():
         '''
         filename = ".".join((filename, "png"))
         filename = os.path.join(Pattern.pattern_path, filename)
-
-        img_x = self.size_x
-        img_y = self.size_y
-        img_size = (img_x, img_y)
         
-        pix_arr = [[(255, 255, 255) for d in range(img_x)] for i in range(img_y)]
-
+        img_size = (self.size_x, self.size_y)
+        
+        new_img = Image.new('RGB', img_size, (255, 255, 255))
+        
         for cell in self.cells:
-            pix_arr[cell[1]][cell[0]] = (0,0,0)
-
-        new_arr = []
-        #Yes x and y should switch places, I didn't mix them up
-        for x in range(img_y):
-            for y in range(img_x):
-                new_arr.append(pix_arr[x][y])
-
-        img = Image.new('RGB', img_size)
-        img.putdata(new_arr)
-        img.save(filename, 'PNG')
+            new_img[cell[1]][cell[0]] = (0, 0, 0)
+        
+        new_img.save(filename, 'PNG')
+        


### PR DESCRIPTION
So I didn't understand anything about creating 2 different arrays just to write same stuff, into the new one (I might have totally missed something, I dunno). I moved all the white pixel creation to **PIL**. 
```python
new_img = Image.new('RGB', img_size, (255, 255, 255))
```
And just replaced all pixel coordinates that we have in **cells** array with black.

I also added .vscode/ to .gitignore